### PR TITLE
fixed a parsing error for the info field

### DIFF
--- a/lib/vcf.rb
+++ b/lib/vcf.rb
@@ -28,7 +28,7 @@ public
     @info = {}
     info_vec = f[7].split(";")
     info_vec.each do |x|
-      keyval = x.split("=", -1)
+      keyval = x.split("=", 2)
       if keyval.size == 2 # If it's key=value
         @info[keyval[0]] = keyval[1]
       else # Otherwise, it's just a flag


### PR DESCRIPTION
when the content of an info field contains a equal sign (=) the split in line 31 yields more than 2 elements. The If-Statement in line 32 then falsely detects this element as a simple flag. 
